### PR TITLE
new: usr: Supports HALO_API_HOSTNAME environment variable.

### DIFF
--- a/apputils/containerized.py
+++ b/apputils/containerized.py
@@ -81,6 +81,7 @@ class Containerized(object):
                  % self.ec2_halo_delta_ver)
         env_expand = {"HALO_API_KEY": "HALO_API_KEY",
                       "HALO_API_SECRET_KEY": "HALO_API_SECRET_KEY",
+                      "HALO_API_HOSTNAME": "HALO_API_HOSTNAME",
                       "AWS_ACCESS_KEY_ID": "AWS_ACCESS_KEY_ID",
                       "AWS_SECRET_ACCESS_KEY": "AWS_SECRET_ACCESS_KEY",
                       "HTTPS_PROXY": "HTTPS_PROXY"}
@@ -99,6 +100,7 @@ class Containerized(object):
         env_vars = {"TARGET": target}
         env_expand = {"HALO_API_KEY": "HALO_API_KEY",
                       "HALO_API_SECRET_KEY": "HALO_API_SECRET_KEY",
+                      "HALO_API_HOSTNAME": "HALO_API_HOSTNAME",
                       "HTTPS_PROXY": "HTTPS_PROXY"}
         result = self.generic_container_launch_attached(image, env_vars,
                                                         env_expand, False)
@@ -111,6 +113,7 @@ class Containerized(object):
                     "AWS_S3_BUCKET": s3_bucket_name}
         env_expand = {"HALO_API_KEY": "HALO_API_KEY",
                       "HALO_API_SECRET_KEY": "HALO_API_SECRET_KEY",
+                      "HALO_API_HOSTNAME": "HALO_API_HOSTNAME",
                       "AWS_ACCESS_KEY_ID": "AWS_ACCESS_KEY_ID",
                       "AWS_SECRET_ACCESS_KEY": "AWS_SECRET_ACCESS_KEY",
                       "HTTPS_PROXY": "HTTPS_PROXY"}
@@ -125,6 +128,7 @@ class Containerized(object):
                     "AWS_S3_BUCKET": s3_bucket_name}
         env_expand = {"HALO_API_KEY": "HALO_API_KEY",
                       "HALO_API_SECRET_KEY": "HALO_API_SECRET_KEY",
+                      "HALO_API_HOSTNAME": "HALO_API_HOSTNAME",
                       "AWS_ACCESS_KEY_ID": "AWS_ACCESS_KEY_ID",
                       "AWS_SECRET_ACCESS_KEY": "AWS_SECRET_ACCESS_KEY",
                       "HTTPS_PROXY": "HTTPS_PROXY"}

--- a/apputils/halo.py
+++ b/apputils/halo.py
@@ -10,10 +10,13 @@ class Halo(object):
         self.halo_api_secret = os.getenv("HALO_API_SECRET_KEY")
         self.halo_api_key_rw = os.getenv("HALO_API_KEY_RW")
         self.halo_api_secret_rw = os.getenv("HALO_API_SECRET_KEY_RW")
+        self.halo_api_host = os.getenv("HALO_API_HOSTNAME")
         self.session = cloudpassage.HaloSession(self.halo_api_key,
-                                                self.halo_api_secret)
+                                                self.halo_api_secret,
+                                                api_host=self.halo_api_host)
         self.rw_session = cloudpassage.HaloSession(self.halo_api_key_rw,
-                                                   self.halo_api_secret_rw)
+                                                   self.halo_api_secret_rw,
+                                                   api_host=self.halo_api_host)
 
     def list_all_servers_formatted(self):
         """Return a list of all servers, formatted for Slack."""


### PR DESCRIPTION
This enables the use of halocelery against non-MTG grid instances.

Closes #25